### PR TITLE
Fix Python 3.7 compatibility

### DIFF
--- a/pbPlist/Switch.py
+++ b/pbPlist/Switch.py
@@ -38,7 +38,6 @@ class Switch(object):
     def __iter__(self):
         """Return the match method once, then stop"""
         yield self.match
-        raise StopIteration # pragma: no cover
 
     def match(self, *args):
         """Indicate whether or not to enter a case suite"""

--- a/pbPlist/__init__.py
+++ b/pbPlist/__init__.py
@@ -29,4 +29,4 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from . import pbPlist
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import setup
 
 setup(
     name = 'pbPlist',
-    version = '1.0.3',
+    version = '1.0.4',
     description = 'Property List Parser and Serializer. Supports XML, Binary, and NeXTSTEP Property Lists.',
     url = 'https://github.com/samdmarshall/pbPlist',
     author = 'Samantha Marshall',


### PR DESCRIPTION
In https://www.python.org/dev/peps/pep-0479/, raising `StopIteration` from a generator is now converted into a runtime error. The suggested replacement is simply to `return` in that case instead. This should be backward compatible.