### PR TITLE
Add cases to load `collections.abc` instead of `collection`

### DIFF
--- a/pbPlist/pbRoot.py
+++ b/pbPlist/pbRoot.py
@@ -32,6 +32,11 @@ from functools import cmp_to_key
 import collections
 from .         import pbItem
 
+try:
+    collections = collections.abc
+except AttributeError:
+    collections = collections
+
 def StringCmp(obj1, obj2):
     result = -1
     if obj1 > obj2:


### PR DESCRIPTION
Because `MutableMapping` is no longer in `collections` but in [`collections.abc`](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping), I've just added a piece of code to tests 2 cases. Please, [show this topic](https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7#answer-53978543).